### PR TITLE
Build docs on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,14 @@ python:
   - "2.7"
   - "2.6"
   - "pypy"
+  - "docs"
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: pip install -r requirements.txt
+install:
+    - if [[ $TRAVIS_PYTHON_VERSION != 'docs' ]]; then pip install -r requirements.txt; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == 'docs' ]]; then pip install sphinx; fi
 
 # command to run tests, e.g. python setup.py test
-script: python setup.py test
+script:
+    - if [[ $TRAVIS_PYTHON_VERSION != 'docs' ]]; then python setup.py test; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == 'docs' ]]; then  sphinx-build -b html docs _build/; fi


### PR DESCRIPTION
I disabled warning test because you have two warnings on the docs (using external images). If you want to turn the warnings into errors, then you should include the -w option into the sphinx-build command and then travis will fail if documentation includes some warnings. 
