### PR TITLE
Feature/remove future library from dependencies

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,3 +11,4 @@ Contributors
 ------------
 
 * Pablo Camino <pablo.camino@feverup.com>
+* Marcos Hernández <marcos.hernandez@feverup.com>

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -39,3 +39,8 @@ History
 ---------------------
 
 * Python 3 import fixes
+
+1.0.2(2019-01-24)
+---------------------
+
+* Remove future library dependency

--- a/pysugarcrm/pysugarcrm.py
+++ b/pysugarcrm/pysugarcrm.py
@@ -1,12 +1,16 @@
 # -*- coding: utf-8 -*-
-from future.standard_library import install_aliases
-install_aliases()
-
-from urllib.parse import urlencode, urlparse, urlunparse
-
 from contextlib import contextmanager
 import json
 import requests
+
+try:
+    # Python3 imports
+    from urllib.parse import urlencode, urlparse, urlunparse
+except ImportError:
+    # Python2 imports
+    from urllib import urlencode
+    from urlparse import urlparse, urlunparse
+
 
 __all__ = ['APIException', 'SugarCRM', 'sugar_api']
 

--- a/setup.py
+++ b/setup.py
@@ -24,12 +24,12 @@ test_requirements = [
 
 setup(
     name='pysugarcrm',
-    version='1.0.1',
+    version='1.0.2',
     description="API Wrapper for SugarCRM v10",
     long_description=readme + '\n\n' + history,
     author="Diego Navarro",
     author_email='diego@feverup.com',
-    url='https://github.com/dnmellen/pysugarcrm',
+    url='https://github.com/Feverup/pysugarcrm',
     packages=[
         'pysugarcrm',
     ],

--- a/tests/test_pysugarcrm.py
+++ b/tests/test_pysugarcrm.py
@@ -16,10 +16,6 @@ from pysugarcrm import SugarCRM, sugar_api
 
 
 class TestPysugarcrm(unittest.TestCase):
-
-    def setUp(self):
-        pass
-
     @responses.activate
     def test_login(self):
         test_access_token = "dsf3898sdjsdfj388jdsj8"


### PR DESCRIPTION
### Description ###
[Future library ](https://python-future.org/) is required and used in the pysugarcrm module but not specified in requirements. Also, it can be removed, as it is only required to install aliases of urllib.

This PR adds an import error check, and solves this compatibility problem.