### PR TITLE
Bugfix to use requests.Session throughout

### DIFF
--- a/pysugarcrm/pysugarcrm.py
+++ b/pysugarcrm/pysugarcrm.py
@@ -53,7 +53,9 @@ class SugarCRM(object):
             "platform": platform,
         }
 
-        response = requests.post(login_url, data=json.dumps(data)).json()
+        # Start requests session
+        self.session = requests.Session()
+        response = self.session.post(login_url, data=json.dumps(data)).json()
 
         # Retrieve auth token
         try:
@@ -61,8 +63,6 @@ class SugarCRM(object):
         except KeyError:
             raise ValueError('No access token received')
 
-        # Start requests session
-        self.session = requests.Session()
         self.session.headers.update(
             {
                 "Content-Type": "application/json",


### PR DESCRIPTION
This fixes a bug when the CRM is behind a load balancer like AWS Elastic Load Balancer. Without this fix, the initial POST could be routed to a different server than the session, causing errors on subsequent calls to the Sugar API.