### PR TITLE
EDIT: conn as global

### DIFF
--- a/pysugarcrm/pysugarcrm.py
+++ b/pysugarcrm/pysugarcrm.py
@@ -23,13 +23,13 @@ class APIException(Exception):
 
 class SugarCRM(object):
     """
-    Sugar CRM API for v10
+    Sugar CRM API for v11
     """
 
     def __init__(
         self, url, username, password, client_id="sugar",
-        login_path="/rest/v10/oauth2/token",
-        base_path="/rest/v10/",
+        login_path="/rest/v11/oauth2/token",
+        base_path="/rest/v11/",
         platform="api"
     ):
         """
@@ -146,6 +146,7 @@ class SugarCRM(object):
 
 @contextmanager
 def sugar_api(*args, **kwargs):
+    global conn
     try:
         conn = SugarCRM(*args, **kwargs)
         yield conn


### PR DESCRIPTION
In order to have the user to input user and password, conn should be set as global

here is an example why

```python
from pysugarcrm import sugar_api
from getpass import getpass

usr = input("Username: ") 
pwd = getpass()

with sugar_api('https://your.sugar.instance/', usr, pwd) as api:
```