### PR TITLE
B2BP-377 - Remove @Feverup/smb from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
 # CODEOWNERS Managed by Platform Squad via Terraform (Fine grained, editable without terraform)
-* @Feverup/smb


### PR DESCRIPTION
## Summary
- Remove `@Feverup/smb` as code owner from the `CODEOWNERS` file in pysugarcrm, as part of B2BP-377

## Test plan
- [x] Verify the `CODEOWNERS` file no longer contains the `@Feverup/smb` entry
- [ ] Confirm no other ownership rules are affected


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes repository ownership routing in `CODEOWNERS` and does not affect runtime code or behavior.
> 
> **Overview**
> Removes the `* @Feverup/smb` catch-all rule from `CODEOWNERS`, leaving no explicit code owner entries in that file.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75b931d016346d6f21b5665966f470c609100db1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->